### PR TITLE
8 nodes, 64 threads

### DIFF
--- a/SimulationRunner/clusters.py
+++ b/SimulationRunner/clusters.py
@@ -248,9 +248,9 @@ class BIOClass(ClusterClass):
     Starting from new HPCC (since March 2022), we can use the threading to speed
     up the computation.
     """
-    def __init__(self, *args, nproc: int = 4, timelimit: Union[float, int] = 2,
+    def __init__(self, *args, nproc: int = 8, timelimit: Union[float, int] = 2,
             cluster_name: str = "BIOCluster", 
-            cores: int = 2, memory: int = 230, **kwargs) -> None:
+            cores: int = 2, memory: int = 115, **kwargs) -> None:
 
         super().__init__(*args, nproc=nproc, timelimit=timelimit,
             cluster_name=cluster_name, cores=cores, **kwargs)
@@ -258,7 +258,7 @@ class BIOClass(ClusterClass):
         self.memory : int = memory
 
     def _queue_directive(self, name: Union[str, TextIO],
-            timelimit: Union[float, int], nproc: int = 4,
+            timelimit: Union[float, int], nproc: int = 8,
             prefix: str = "#SBATCH") -> str:
         """Generate mpi_submit with coma specific parts"""
         _ = timelimit
@@ -273,10 +273,10 @@ class BIOClass(ClusterClass):
         qstring += prefix + " --ntasks-per-node=2\n"
 
         #Number of cpus (threads) per task (process)
-        qstring += prefix + " --cpus-per-task=32\n"
+        qstring += prefix + " --cpus-per-task=16\n"
 
-        # exclusive, request a full node
-        qstring += prefix + " --exclusive\n"
+        # # exclusive, request a full node
+        # qstring += prefix + " --exclusive\n"
 
         # mem instead of mem-per-task, since that does not work in new HPCC
         qstring += prefix + " --mem={}G\n".format(self.memory)


### PR DESCRIPTION
I've tried several different settings to run MP-Gadget on HPCC. Here is the best setting I've found so far.

```bash
#!/bin/bash
#SBATCH --partition=short
#SBATCH --job-name=test
#SBATCH --time=2:0:00
#SBATCH --nodes=8
#SBATCH --ntasks-per-node=2
#SBATCH --cpus-per-task=16
#SBATCH --mem=115G
#SBATCH --mail-type=end
export OMP_NUM_THREADS=32

module unload openmpi
# mpich is faster
module load mpich

module list
mpirun ./MP-Gadget mpgadget.param
```

----
In mpgadget.param, set MaxMemSizePerNode = 112500.

And m, r, and x nodes are also slow, so submit the mpi_submit with
sbatch --exclude=c01,c02,c03,c04,c05,c06,c07,c08,c09,c10,c11,c12,c13,c14,c15,c16,c17,c18,c19,c20,c21,c22,c23,c24,c25,c26,c27,c28,c29,c30,c31,c32,c33,c34,c35,c36,c37,c38,c39,c40,c41,c42,c43,c44,c45,c46,c47,c48,m02,r01,r02,r03,x01,x02,x03,x04,x05,x06 mpi_submit


Reasons:
----

I removed the --exclusive. If we use --exclusive, we cannot use more than 4 nodes because each intel node has 256G, and on HPCC, we cannot submit more than 1T per job. If we request 32 CPUs per node, it would already request a full node on intel nodes. Thus, I decreased the memory request to 115G per node. In this case, we can submit to 8 nodes.

I also decreased the --cpus-per-task to 16 (but set the OMP_NUM_THREADS to 32). MP-Gadget can detect we want to run hyperthreading and assign 2 threads per CPU. Therefore, it's effectively 2 ranks per node and 32 threads per rank. I checked the SLURM output and confirmed the results:

[ 000000.00 ] Running on 16 MPI Ranks.
[ 000000.00 ]      32 OpenMP Threads.

Previously, we were running with 8 MPI ranks and 32 threads.

I tested by running a 512^3 100 cMpc/h simulation until z = 0:
* 8 ranks, 32 threads: wall time ~ 53 hours
* 16 ranks, 32 threads: wall time ~ 29 hours